### PR TITLE
Fix for multi sensor

### DIFF
--- a/.github/workflows/ReleaseMSBuild.yml
+++ b/.github/workflows/ReleaseMSBuild.yml
@@ -1,26 +1,13 @@
-# This workflow uses actions that are not certified by GitHub.
-# They are provided by a third-party and are governed by
-# separate terms of service, privacy policy, and support
-# documentation.
-
-name: ReleaseMSBuild
+name: C++ Build and Release Windows
 
 on:
   release:
     types: [published]
 
 env:
-  # Path to the solution file relative to the root of the project.
   SOLUTION_FILE_PATH: PL_Windows_Proc_Serv.sln
-
-  # Configuration type to build.
-  # You can convert this to a build matrix if you need coverage of multiple configuration types.
-  # https://docs.github.com/actions/learn-github-actions/managing-complex-workflows#using-a-build-matrix
-  BUILD_CONFIGURATION: Debug
-
-permissions:
-  contents: read
-
+  BUILD_CONFIGURATION: Release
+  
 jobs:
   build:
     runs-on: windows-latest
@@ -33,38 +20,39 @@ jobs:
       uses: actions/checkout@v3
       with:
         submodules: recursive
-
+     
     - name: Add MSBuild to PATH
-      uses: microsoft/setup-msbuild@v1.0.2
+      uses: microsoft/setup-msbuild@v1.3.1
+      with:
+        msbuild-architecture: x64
 
     - name: Restore NuGet packages
       run: nuget restore ${{env.SOLUTION_FILE_PATH}}
-
+        
     - name: Build
       # Add additional options to the MSBuild command line here (like platform or verbosity level).
       # See https://docs.microsoft.com/visualstudio/msbuild/msbuild-command-line-reference
-      run: msbuild /m /p:Configuration=${{env.BUILD_CONFIGURATION}} ${{env.SOLUTION_FILE_PATH}} /m:1 # /m:1 set to one parallel build
-
-    - uses: actions/checkout@master
-    - name: Copy Config and README
-      run: |
-        cp "PL_Windows_Proc_Serv/Config.json" "/build/Config.json"
-        cp "README.md" "/build/README.md"
-
+      run: | 
+        msbuild /m /p:Configuration=${{env.BUILD_CONFIGURATION}} ${{env.SOLUTION_FILE_PATH}} /m:1 # /m:1 set to one parallel build
+        mkdir "build"
+        ls
+        ls build/
+        cp "x64/${{env.BUILD_CONFIGURATION}}/PL_Windows_Proc_Serv.exe" "build/PL_Windows_Proc_Serv.exe"
+        cp "PL_Windows_Proc_Serv/Config.json" "build/Config.json"
+        cp "README.md" "build/README.md"
+    
     - name: Zip Docs and Build
       uses: TheDoctor0/zip-release@0.7.6
       with:
-       path: /build/* # File to add to the archive
+       directory: build/ # File to add to the archive
+       path: ./*
        Filename: PL_Windows_Proc_Serv.zip # The name of the archive file
 
     - name: Upload to Release
       uses: softprops/action-gh-release@v1
       with:
         files: |
-          PL_Windows_Proc_Serv.zip
+          build/PL_Windows_Proc_Serv.zip
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
-
-
       

--- a/PL_Windows_Proc_Serv/Config.json
+++ b/PL_Windows_Proc_Serv/Config.json
@@ -18,7 +18,7 @@
 			"Port": "8086"
 		},
 		"WAVSubPipelineConfig": {
-			"EnableSubPipeline": "True",
+			"EnableSubPipeline": "False",
 			"WAVAccumulatorModule": {
 				"RecordingPeriod": 10,
 				"ContinuityThresholdFactor": 1

--- a/PL_Windows_Proc_Serv/PL_Windows_Proc_Serv.cpp
+++ b/PL_Windows_Proc_Serv/PL_Windows_Proc_Serv.cpp
@@ -25,6 +25,7 @@
 #include "WinTCPTxModule.h"
 #include "ChunkToBytesModule.h"
 #include "FFTModule.h"
+#include "WinMultiClientTCPRxModule.h"
 
 /* External Libraries */
 #include <plog/Appenders/ColorConsoleAppender.h>
@@ -161,13 +162,14 @@ int main()
 	// ------------
 
 	// Start of Processing Chain
-	auto pTCPRXModule = std::make_shared<WinTCPRxModule>(strTCPRxIP, strTCPRxPort, u16DefaultModuleBufferSize, u16DefualtNetworkDataTransmissionSize);
+	auto pMultiClientTCPRXModule = std::make_shared<WinMultiClientTCPRxModule>(strTCPRxIP, strTCPRxPort, u16DefaultModuleBufferSize, u16DefualtNetworkDataTransmissionSize);
 	auto pWAVSessionProcModule = std::make_shared<SessionProcModule>(u16DefaultModuleBufferSize);
 	auto pSessionChunkRouter = std::make_shared<RouterModule>(u16DefaultModuleBufferSize);
 
 	// FFT proc
 	auto pFFTProcModule= std::make_shared<FFTModule>(u16DefaultModuleBufferSize);
-	
+	pFFTProcModule->SetGenerateMagnitudeData(true);
+
 	// To Go Adapter
 	auto pToJSONModule = std::make_shared<ToJSONModule>();
 	auto pChunkToBytesModule = std::make_shared<ChunkToBytesModule>(u16DefaultModuleBufferSize, u16DefualtNetworkDataTransmissionSize);
@@ -178,7 +180,7 @@ int main()
 	// ------------
 
 	// Connection pipeline modules
-	pTCPRXModule->SetNextModule(pWAVSessionProcModule);
+	pMultiClientTCPRXModule->SetNextModule(pWAVSessionProcModule);
 	pWAVSessionProcModule->SetNextModule(pSessionChunkRouter);
 	pSessionChunkRouter->SetNextModule(nullptr); // Note: this module needs registered outputs not set outputs as it is a one to many
 
@@ -232,7 +234,7 @@ int main()
 	// Starting chain from its end to start
 	pSessionChunkRouter->StartProcessing();
 	pWAVSessionProcModule->StartProcessing();
-	pTCPRXModule->StartProcessing();
+	pMultiClientTCPRXModule->StartProcessing();
 	pTCPTXModule->StartProcessing();
 	pChunkToBytesModule->StartProcessing();
 	pToJSONModule->StartProcessing();

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ This module is configured uising the ```Config.json``` file.
 
 ``` mermaid 
 graph TD; 
-  pTCPRXModule-->pWAVSessionProcModule
+  pMultiClientTCPRXModule-->pWAVSessionProcModule
   pWAVSessionProcModule-->pSessionChunkRouter
   pFFTProcModule-->pToJSONModule
   pToJSONModule-->pChunkToBytesModule


### PR DESCRIPTION
The processing server now allows for a sensor to be allocated a TCP port on which to operate.

The client (sensor) will create a connection and the server will respond with the port it should use.